### PR TITLE
ghactivity_team shortcode: Display info for teams

### DIFF
--- a/core.ghactivity.php
+++ b/core.ghactivity.php
@@ -775,15 +775,14 @@ class GHActivity_Calls {
 			'post_status'    => 'publish',
 			'posts_per_page' => -1,  // Show all posts.
 			'date_query'     => array(
-				'after' => $date_start,
-				'before' => $date_end,
+				'after'     => $date_start,
+				'before'    => $date_end,
 				'inclusive' => true,
 			),
 			'tax_query'      => array(
-				'relation' => 'AND',
 				array(
 					'taxonomy' => 'ghactivity_actor',
-					'field'    => 'name',
+					'field'    => 'slug',
 					'terms'    => $person,
 				),
 				array(
@@ -807,7 +806,6 @@ class GHActivity_Calls {
 
 		while ( $query->have_posts() ) {
 			$query->the_post();
-
 			$terms = get_the_terms( $query->post->ID, 'ghactivity_event_type' );
 
 			/**
@@ -845,17 +843,15 @@ class GHActivity_Calls {
 						}
 					}
 				}
-			} else {
-				if ( $terms && ! is_wp_error( $terms ) ) {
-					foreach ( $terms as $term ) {
-						if ( isset( $count[ $term->slug ] ) ) {
-							$count[ $term->slug ]++;
-						} else {
-							$count[ $term->slug ] = 1;
-						}
+			} elseif ( $terms && ! is_wp_error( $terms ) ) {
+				foreach ( $terms as $term ) {
+					if ( isset( $count[ $term->slug ] ) ) {
+						$count[ $term->slug ]++;
+					} else {
+						$count[ $term->slug ] = 1;
 					}
 				}
-			} // End if().
+			} // End elseif.
 
 			/**
 			 * Filter the final array of event types and matching counts after calculation.
@@ -1043,13 +1039,12 @@ class GHActivity_Calls {
 	 * @param string       $date_end        End date range, using a strtotime compatible format.
 	 * @param string       $person          Get stats for a specific GitHub username.
 	 * @param string|array $repo            Get stats for a specific GitHub repo, or a list of repos.
-	 * @param bool         $split_per_actor Split counts per actor.
 	 *
 	 * @return $count      Array of count of actions and info about person/repo.
 	 */
-	public static function get_summary_counts( $date_start, $date_end, $person = '', $repo, $split_per_actor = false ) {
+	public static function get_summary_counts( $date_start, $date_end, $person = '', $repo ) {
 		// Action count during that period.
-		$action_count = self::count_posts_per_event_type( $date_start, $date_end, $person, $repo, $split_per_actor );
+		$action_count = self::count_posts_per_event_type( $date_start, $date_end, $person, $repo );
 
 		// Remove all actions with a count of 0. We won't need to display them.
 		$action_count = array_filter( $action_count );
@@ -1058,9 +1053,9 @@ class GHActivity_Calls {
 		 * Let's loop through our array of actions taken,
 		 * and replace the taxonomy slugs used when counting posts by the taxonomy names, better for display.
 		 */
-		foreach( $action_count as $type => $count ) {
-			// Get the pretty name for each taxonomy
-			$tax_info = get_term_by( 'slug', $type, 'ghactivity_event_type' );
+		foreach ( $action_count as $type => $count ) {
+			// Get the pretty name for each taxonomy.
+			$tax_info  = get_term_by( 'slug', $type, 'ghactivity_event_type' );
 			$type_name = $tax_info->name;
 
 			// Add the new pretty names to the array, matching them to their value.

--- a/reports.ghactivity.php
+++ b/reports.ghactivity.php
@@ -64,7 +64,7 @@ class GHActivity_Reports {
 		 */
 		$dates = apply_filters( 'ghactivity_main_report_dates', $dates );
 
-		$action_count = GHActivity_Calls::get_summary_counts( $dates['date_start'], $dates['date_end'], $people, $repo, false );
+		$action_count = GHActivity_Calls::get_summary_counts( $dates['date_start'], $dates['date_end'], $people, $repo );
 
 		$chart_data = GHActivity_Charts::get_action_chart_data( $action_count );
 

--- a/shortcodes/team-activity.php
+++ b/shortcodes/team-activity.php
@@ -52,8 +52,20 @@ function ghactivity_team_shortcode( $atts ) {
 	 */
 	$repo = apply_filters( 'ghactivity_team_report_repo_to_monitor', '' );
 
-	$action_count = GHActivity_Calls::get_summary_counts( $date_start, $date_end, $team, $repo, false );
+	$action_count = GHActivity_Calls::get_summary_counts( $date_start, $date_end, $team, $repo );
 
+	return team_activity_markup( $action_count, $team );
+}
+
+/**
+ * Generates HTML for team_activity shortcode
+ *
+ * @since x.x.x
+ *
+ * @param array $action_count Array of attributes.
+ * @param array $team Array of teammates.
+ */
+function team_activity_markup( $action_count, $team ) {
 	$report = sprintf(
 		'<header class="page-header"><h2>%s</h2>',
 		esc_html__( 'In the past 7 days, here is what the team did:', 'ghactivity' )


### PR DESCRIPTION
Fixes #4 

To test:

* Make sure you have enough GH events tracked, and there at least 1 team created
* Create a new page with `[ghactivity_team team=$team_name]` shortcode
* Make sure it renders valid numbers